### PR TITLE
License Header Info Added 

### DIFF
--- a/src/main/scala/io/pravega/connectors/spark/JsonUtils.scala
+++ b/src/main/scala/io/pravega/connectors/spark/JsonUtils.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import io.pravega.client.stream.StreamCut

--- a/src/main/scala/io/pravega/connectors/spark/PravegaMicroBatchReader.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaMicroBatchReader.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import java.io.IOException

--- a/src/main/scala/io/pravega/connectors/spark/PravegaRecordToUnsafeRowConverter.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaRecordToUnsafeRowConverter.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import org.apache.spark.sql.catalyst.expressions.UnsafeRow

--- a/src/main/scala/io/pravega/connectors/spark/PravegaSourceOffset.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaSourceOffset.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import io.pravega.client.stream.StreamCut

--- a/src/main/scala/io/pravega/connectors/spark/PravegaSourceProvider.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaSourceProvider.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import java.net.URI

--- a/src/main/scala/io/pravega/connectors/spark/PravegaStreamWriter.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaStreamWriter.scala
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.pravega.connectors.spark
 
 import java.nio.ByteBuffer


### PR DESCRIPTION
License Info has been added as follows to the source files as per issue : [pravega/spark-connectors/#4](https://github.com/pravega/spark-connectors/issues/4)
/**
 * Copyright (c) 2019 Dell Inc., or its subsidiaries. All Rights Reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 */ # #

Signed-off-by: incia94 <incia.anand@dell.com>