### PR TITLE
Issue 43: UnsafeRow possible Bug due to Null Values

### DIFF
--- a/src/main/scala/io/pravega/connectors/spark/PravegaRecordToUnsafeRowConverter.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaRecordToUnsafeRowConverter.scala
@@ -19,6 +19,7 @@ class PravegaRecordToUnsafeRowConverter {
 
   def toUnsafeRow(event: Array[Byte], scope: String, streamName: String, segmentId: Long, offset: Long): UnsafeRow = {
     rowWriter.reset()
+    rowWriter.zeroOutNullBytes()
     rowWriter.write(0, event)
     rowWriter.write(1, UTF8String.fromString(scope))
     rowWriter.write(2, UTF8String.fromString(streamName))


### PR DESCRIPTION
Added rowWriter.zeroOutNullBytes() to avoid a possible bug as data source v2 doesnt accept null values


Signed-off-by: incia94 <incia.anand@dell.com>