### PR TITLE
[issue-51] Upgrade to Pravega 0.7

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,11 +22,11 @@ scalaTestVersion=3.0.5
 scalaVersion=2.11.8
 shadowGradlePlugin=4.0.2
 slf4jApiVersion=1.7.25
-sparkVersion=2.4.1
+sparkVersion=2.4.5
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.5.0-SNAPSHOT
-pravegaVersion=0.5.0
+connectorVersion=0.7.0-SNAPSHOT
+pravegaVersion=0.7.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/src/main/scala/io/pravega/connectors/spark/PravegaSourceProvider.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaSourceProvider.scala
@@ -348,8 +348,6 @@ class PravegaSourceProvider extends DataSourceV2
       val allowCreateStream = caseInsensitiveParams.getOrElse(PravegaSourceProvider.ALLOW_CREATE_STREAM_OPTION_KEY, "true").toBoolean
       if (allowCreateStream) {
         var streamConfig = StreamConfiguration.builder
-          .scope(scopeName)
-          .streamName(streamName)
         streamConfig = caseInsensitiveParams.get(PravegaSourceProvider.DEFAULT_NUM_SEGMENTS_OPTION_KEY) match {
           case Some(n) => streamConfig.scalingPolicy(ScalingPolicy.fixed(n.toInt))
           case None => streamConfig

--- a/src/main/scala/io/pravega/connectors/spark/PravegaWriter.scala
+++ b/src/main/scala/io/pravega/connectors/spark/PravegaWriter.scala
@@ -14,8 +14,8 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import io.pravega.client.stream.impl.ByteBufferSerializer
-import io.pravega.client.stream.{EventStreamWriter, EventWriterConfig, Transaction, TxnFailedException}
-import io.pravega.client.{ClientConfig, ClientFactory}
+import io.pravega.client.stream.{TransactionalEventStreamWriter, EventWriterConfig, Transaction, TxnFailedException}
+import io.pravega.client.{ClientConfig, EventStreamClientFactory}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.{AttributeReference, Cast, Literal, UnsafeProjection}
@@ -53,12 +53,12 @@ class PravegaWriter(
                      schema: StructType)
   extends DataSourceWriter with StreamWriter with Logging {
 
-  private def createClientFactory: ClientFactory = {
-    ClientFactory.withScope(scopeName, clientConfig)
+  private def createClientFactory: EventStreamClientFactory = {
+    EventStreamClientFactory.withScope(scopeName, clientConfig)
   }
 
-  private def createWriter(clientFactory: ClientFactory): EventStreamWriter[ByteBuffer] = {
-    clientFactory.createEventWriter(
+  private def createWriter(clientFactory: EventStreamClientFactory): TransactionalEventStreamWriter[ByteBuffer] = {
+    clientFactory.createTransactionalEventWriter(
       streamName,
       new ByteBufferSerializer,
       EventWriterConfig.builder
@@ -185,8 +185,8 @@ class PravegaDataWriter(
 
   private val projection = createProjection
 
-  private val clientFactory = ClientFactory.withScope(scopeName, clientConfig)
-  private val writer: EventStreamWriter[ByteBuffer] = clientFactory.createEventWriter(
+  private val clientFactory = EventStreamClientFactory.withScope(scopeName, clientConfig)
+  private val writer: TransactionalEventStreamWriter[ByteBuffer] = clientFactory.createTransactionalEventWriter(
     streamName,
     new ByteBufferSerializer,
     EventWriterConfig


### PR DESCRIPTION
Signed-off-by: Brian Zhou <brian.zhou@emc.com>

**Changes**
- Upgrade Pravega client to 0.7 and Spark to 2.4.5
- Fix compatibility issues

**Testing**
`./gradlew clean build` passes on linux, but on windows I met the same issue as https://github.com/maiflai/gradle-scalatest/issues/30 and still cannot fix.
Tested on local standalone Pravega 0.7.0 and Spark 2.4.5, reading app can work fine.


