### PR TITLE
[Issue-58] Update the spark version to 2.4.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ scalaTestVersion=3.0.5
 scalaVersion=2.11.8
 shadowGradlePlugin=4.0.2
 slf4jApiVersion=1.7.25
-sparkVersion=2.4.5
+sparkVersion=2.4.6
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT


### PR DESCRIPTION
Signed-off-by: Youmin Han <Youmin.Han@dell.com>

Fixes #58 

The following are the results for testing: 
`Tests: succeeded 35, failed 0, canceled 0, ignored 0, pending 0`

There are four `POSSIBLE THREAD LEAK IN SUITE` warnings that may need to be solved in the future. However, these are not caused by upgrading and happened in the previous version. 

1. `===== POSSIBLE THREAD LEAK IN SUITE io.pravega.connectors.spark.PravegaDataSourceSuite, thread names: rpc-boss-3-1, storage-io-147, storage-io-4, storage-io-158, nioEventLoopGroup-11-1, core-26, storage-io-117, storage-io-96, core-6, storage-io-26, storage-io-124, nioEventLoopGroup-146-2, storage-io-135, storage-io-10, storage-io-60, core-15, storage-io-21, storage-io-15, storage-io-106, storage-io-132, storage-io-128, storage-io-89, storage-io-37, nioEventLoopGroup-144-1, grpc-default-worker-ELG-9-1, storage-io-113, storage-io-43, nioEventLoopGroup-145-2, storage-io-48, storage-io-78, nioEventLoopGroup-12-2, grpc-default-executor-3, storage-io-102, storage-io-139, nioEventLoopGroup-146-4, storage-io-169, storage-io-19, storage-io-59, storage-io-140, storage-io-32, storage-io-151, storage-io-82, core-3, storage-io-85, storage-io-47, storage-io-74, storage-io-71, storage-io-93, storage-io-69, storage-io-125, storage-io-165, core-20, storage-io-58, nioEventLoopGroup-143-4, storage-io-109, core-21, storage-io-7, pool-24-thread-1, core-19, nioEventLoopGroup-142-2, storage-io-103, storage-io-114, storage-io-143, core-7, storage-io-154, nioEventLoopGroup-142-3, storage-io-36, storage-io-25, storage-io-14, storage-io-65, nioEventLoopGroup-13-3, storage-io-176, storage-io-54, storage-io-136, storage-io-105, nioEventLoopGroup-144-4, storage-io-95, storage-io-108, storage-io-1, storage-io-133, storage-io-148, core-23, storage-io-66, core-12, storage-io-122, storage-io-116, storage-io-55, nioEventLoopGroup-145-1, storage-io-77, storage-io-119, storage-io-173, storage-io-90, storage-io-159, core-27, storage-io-99, storage-io-162, storage-io-138, storage-io-127, storage-io-5, nioEventLoopGroup-143-1, core-16, core-1, storage-io-83, storage-io-73, storage-io-88, ForkJoinPool-1-worker-1, storage-io-110, core-24, storage-io-33, storage-io-72, storage-io-161, grpc-default-executor-4, storage-io-18, storage-io-149, storage-io-29, storage-io-44, storage-io-6, core-30, storage-io-150, core-4, storage-io-84, storage-io-177, storage-io-137, storage-io-22, core-13, storage-io-104, grpc-default-executor-0, storage-io-144, storage-io-62, storage-io-51, storage-io-126, nioEventLoopGroup-142-4, storage-io-166, storage-io-40, storage-io-121, nioEventLoopGroup-12-3, storage-io-11, storage-io-115, storage-io-94, grpc-default-worker-ELG-9-2, storage-io-155, storage-io-118, storage-io-172, nioEventLoopGroup-144-3, nioEventLoopGroup-13-4, storage-io-56, storage-io-107, core-17, storage-io-39, storage-io-156, storage-io-174, storage-io-8, core-28, grpc-default-executor-1, nioEventLoopGroup-13-1, storage-io-152, storage-io-167, storage-io-178, core-22, core-2, storage-io-129, core-11, nioEventLoopGroup-145-4, storage-io-163, grpc-shared-destroyer-0, grpc-default-executor-5, storage-io-23, nioEventLoopGroup-12-4, storage-io-63, nioEventLoopGroup-146-1, storage-io-100, storage-io-17, storage-io-9, nioEventLoopGroup-143-2, storage-io-160, storage-io-98, storage-io-111, storage-io-28, storage-io-45, storage-io-34, storage-io-76, storage-io-12, storage-io-67, storage-io-141, storage-io-52, storage-io-171, storage-io-2, storage-io-130, storage-io-30, storage-io-87, storage-io-80, grpc-default-worker-ELG-9-3, core-9, storage-io-91, storage-io-41, storage-io-16, storage-io-123, storage-io-134, storage-io-79, storage-io-61, storage-io-175, storage-io-157, nioEventLoopGroup-13-2, storage-io-50, core-5, storage-io-146, core-14, grpc-default-executor-2, storage-io-20, storage-io-101, nioEventLoopGroup-146-3, storage-io-168, shuffle-boss-6-1, nioEventLoopGroup-145-3, HttpServer-0, core-29, core-25, storage-io-153, storage-io-112, storage-io-97, storage-io-164, storage-io-49, storage-io-38, core-10, nioEventLoopGroup-144-2, storage-io-57, storage-io-42, nioEventLoopGroup-12-1, storage-io-142, storage-io-120, storage-io-31, storage-io-68, storage-io-92, storage-io-46, storage-io-53, SessionTracker, storage-io-27, process reaper, storage-io-131, ForkJoinPool-1-worker-3, storage-io-13, storage-io-75, core-18, storage-io-86, grpc-default-worker-ELG-9-4, storage-io-170, storage-io-145, nioEventLoopGroup-143-3, storage-io-3, storage-io-35, nioEventLoopGroup-142-1, storage-io-24, storage-io-70, org.apache.hadoop.fs.FileSystem$Statistics$StatisticsDataReferenceCleaner, storage-io-81, storage-io-64, core-8 =====`

2. `===== POSSIBLE THREAD LEAK IN SUITE io.pravega.connectors.spark.PravegaMicroBatchV2SourceSuite, thread names: state-store-maintenance-task, storage-io-196, storage-io-188, pool-67-thread-1, nioEventLoopGroup-368-1, nioEventLoopGroup-370-1, storage-io-199, nioEventLoopGroup-367-3, nioEventLoopGroup-371-3, storage-io-180, nioEventLoopGroup-155-1, storage-io-190, nioEventLoopGroup-371-4, nioEventLoopGroup-368-2, nioEventLoopGroup-367-1, nioEventLoopGroup-357-2, storage-io-195, nioEventLoopGroup-156-3, shuffle-boss-151-1, nioEventLoopGroup-156-4, nioEventLoopGroup-369-1, storage-io-198, nioEventLoopGroup-156-2, storage-io-187, storage-io-184, nioEventLoopGroup-153-1, nioEventLoopGroup-369-4, storage-io-191, nioEventLoopGroup-357-3, nioEventLoopGroup-368-3, ControllerServiceMain-SendThread(127.0.0.1:42625), grpc-default-executor-7, nioEventLoopGroup-367-2, nioEventLoopGroup-357-4, storage-io-185, storage-io-183, nioEventLoopGroup-156-1, storage-io-192, nioEventLoopGroup-157-3, nioEventLoopGroup-157-2, nioEventLoopGroup-369-3, storage-io-182, nioEventLoopGroup-370-2, storage-io-186, nioEventLoopGroup-371-2, storage-io-200, grpc-default-executor-6, nioEventLoopGroup-368-4, grpc-default-executor-8, storage-io-197, nioEventLoopGroup-157-1, nioEventLoopGroup-153-3, nioEventLoopGroup-157-4, storage-io-179, storage-io-193, nioEventLoopGroup-370-4, nioEventLoopGroup-370-3, nioEventLoopGroup-153-4, nioEventLoopGroup-369-2, grpc-default-executor-9, storage-io-189, nioEventLoopGroup-357-1, rpc-boss-148-1, storage-io-181, nioEventLoopGroup-371-1, HttpServer-1-0, storage-io-194, nioEventLoopGroup-367-4 =====`

3. `===== POSSIBLE THREAD LEAK IN SUITE io.pravega.connectors.spark.PravegaSourceStressSuite, thread names: nioEventLoopGroup-542-1, HttpServer-2-0, nioEventLoopGroup-527-2, nioEventLoopGroup-537-1, nioEventLoopGroup-523-2, nioEventLoopGroup-518-3, nioEventLoopGroup-532-3, nioEventLoopGroup-522-4, nioEventLoopGroup-537-4, nioEventLoopGroup-522-1, nioEventLoopGroup-536-3, nioEventLoopGroup-524-3, nioEventLoopGroup-533-2, nioEventLoopGroup-536-1, nioEventLoopGroup-531-3, nioEventLoopGroup-530-1, nioEventLoopGroup-540-3, nioEventLoopGroup-539-4, nioEventLoopGroup-538-4, shuffle-boss-376-1, nioEventLoopGroup-535-3, nioEventLoopGroup-539-1, nioEventLoopGroup-519-3, nioEventLoopGroup-382-2, nioEventLoopGroup-534-3, nioEventLoopGroup-531-2, nioEventLoopGroup-520-1, nioEventLoopGroup-541-3, nioEventLoopGroup-529-3, nioEventLoopGroup-533-1, nioEventLoopGroup-381-2, rpc-boss-373-1, nioEventLoopGroup-526-1, nioEventLoopGroup-529-1, nioEventLoopGroup-537-2, ControllerServiceMain-SendThread(127.0.0.1:37159), nioEventLoopGroup-525-4, nioEventLoopGroup-536-4, nioEventLoopGroup-529-4, nioEventLoopGroup-523-1, nioEventLoopGroup-518-4, nioEventLoopGroup-538-3, nioEventLoopGroup-380-1, nioEventLoopGroup-528-3, nioEventLoopGroup-532-1, nioEventLoopGroup-522-3, nioEventLoopGroup-531-4, nioEventLoopGroup-541-2, nioEventLoopGroup-532-2, nioEventLoopGroup-382-1, nioEventLoopGroup-527-1, nioEventLoopGroup-521-3, pool-110-thread-1, nioEventLoopGroup-526-4, nioEventLoopGroup-533-4, nioEventLoopGroup-540-2, nioEventLoopGroup-381-3, nioEventLoopGroup-531-1, nioEventLoopGroup-523-4, nioEventLoopGroup-519-2, nioEventLoopGroup-528-2, nioEventLoopGroup-534-2, nioEventLoopGroup-524-2, nioEventLoopGroup-521-4, nioEventLoopGroup-381-1, nioEventLoopGroup-520-2, nioEventLoopGroup-542-2, nioEventLoopGroup-528-4, nioEventLoopGroup-378-4, nioEventLoopGroup-530-3, grpc-default-boss-ELG-383-1, nioEventLoopGroup-538-2, nioEventLoopGroup-535-1, nioEventLoopGroup-519-1, nioEventLoopGroup-528-1, nioEventLoopGroup-381-4, nioEventLoopGroup-535-2, nioEventLoopGroup-542-3, nioEventLoopGroup-534-1, nioEventLoopGroup-520-3, nioEventLoopGroup-378-3, nioEventLoopGroup-382-4, nioEventLoopGroup-530-4, nioEventLoopGroup-524-1, nioEventLoopGroup-541-1, nioEventLoopGroup-525-1, nioEventLoopGroup-533-3, nioEventLoopGroup-540-1, nioEventLoopGroup-526-3, nioEventLoopGroup-530-2, nioEventLoopGroup-534-4, nioEventLoopGroup-518-2, nioEventLoopGroup-521-2, nioEventLoopGroup-532-4, nioEventLoopGroup-527-4, nioEventLoopGroup-524-4, nioEventLoopGroup-537-3, nioEventLoopGroup-538-1, nioEventLoopGroup-536-2, nioEventLoopGroup-529-2, nioEventLoopGroup-525-2, nioEventLoopGroup-522-2, nioEventLoopGroup-378-1, nioEventLoopGroup-541-4, nioEventLoopGroup-535-4, nioEventLoopGroup-521-1, nioEventLoopGroup-523-3, nioEventLoopGroup-542-4, nioEventLoopGroup-539-2, nioEventLoopGroup-540-4, nioEventLoopGroup-525-3, nioEventLoopGroup-539-3, nioEventLoopGroup-378-2, nioEventLoopGroup-519-4, nioEventLoopGroup-518-1, nioEventLoopGroup-520-4, nioEventLoopGroup-526-2, nioEventLoopGroup-527-3, nioEventLoopGroup-382-3 =====`

4. `===== POSSIBLE THREAD LEAK IN SUITE io.pravega.connectors.spark.PravegaSinkSuite, thread names: state-store-maintenance-task, HttpServer-3-0, nioEventLoopGroup-691-2, clientInternal-640-2, nioEventLoopGroup-693-1, nioEventLoopGroup-552-2, clientInternal-649-1, grpc-default-executor-11, clientInternal-653-1, pool-160-thread-1, nioEventLoopGroup-553-3, nioEventLoopGroup-682-3, clientInternal-650-1, nioEventLoopGroup-694-1, clientInternal-653-2, nioEventLoopGroup-549-1, grpc-default-executor-12, nioEventLoopGroup-552-1, clientInternal-652-1, clientInternal-649-2, nioEventLoopGroup-692-3, nioEventLoopGroup-549-4, nioEventLoopGroup-686-2, nioEventLoopGroup-553-1, nioEventLoopGroup-694-2, nioEventLoopGroup-552-4, grpc-default-executor-13, nioEventLoopGroup-692-2, clientInternal-652-2, ControllerServiceMain-SendThread(127.0.0.1:34503), clientInternal-651-1, nioEventLoopGroup-549-2, nioEventLoopGroup-682-1, nioEventLoopGroup-693-3, nioEventLoopGroup-694-3, nioEventLoopGroup-691-1, CacheManager RUNNING, nioEventLoopGroup-553-2, nioEventLoopGroup-686-3, nioEventLoopGroup-695-3, clientInternal-650-2, nioEventLoopGroup-686-1, nioEventLoopGroup-553-4, nioEventLoopGroup-691-3, nioEventLoopGroup-695-1, nioEventLoopGroup-552-3, grpc-default-executor-10, rpc-boss-544-1, clientInternal-651-2, nioEventLoopGroup-692-1, clientInternal-640-1, nioEventLoopGroup-549-3, clientInternal-644-2, nioEventLoopGroup-682-2, nioEventLoopGroup-551-1, nioEventLoopGroup-695-2, shuffle-boss-547-1, nioEventLoopGroup-693-2, clientInternal-644-1 =====`

