### PR TITLE
[NPS-7379] Fix the double dependencies tag in the pom file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
 language: scala
 install: true
 jdk:
-  - oraclejdk8
+  - openjdk8
 scala:
   - 2.11.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: junitVersion
     testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
     testCompile group: 'org.scalatest', name: 'scalatest_2.11', version: scalaTestVersion
-    testRuntime group: 'org.pegdown', name: 'pegdown', version: pegDownVersion
+    testRuntimeOnly group: 'org.pegdown', name: 'pegdown', version: pegDownVersion
     testCompile group: 'org.apache.spark', name: 'spark-sql_2.11', version: sparkVersion
     testCompile group: 'org.apache.spark', name: 'spark-core_2.11', version: sparkVersion, classifier: 'tests'
     testCompile group: 'org.apache.spark', name: 'spark-catalyst_2.11', version: sparkVersion, classifier: 'tests'


### PR DESCRIPTION
1. Fix the issue of showing two "dependencies" tag in the pom file when packaging the spark connector.
2. Pass all the tests for spark connector.


Signed-off-by: Youmin Han <Youmin.Han@dell.com>