### PR TITLE
Pravega upgrade 0.8 and grpc-netty upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,8 +109,16 @@ shadowJar {
     zip64 = true
     mergeServiceFiles()
 
-    relocate 'io.netty', 'io.pravega.shaded.io.netty'
-    relocate 'com.google', 'io.pravega.shaded.com.google'
+    // relocate pravega client's dependencies to minimize conflicts
+    relocate "org.apache.commons", "io.pravega.shaded.org.apache.commons"
+    relocate "com.google", "io.pravega.shaded.com.google"
+    relocate "io.grpc", "io.pravega.shaded.io.grpc"
+    relocate "com.squareup.okhttp", "io.pravega.shaded.com.squareup.okhttp"
+    relocate "okio", "io.pravega.shaded.okio"
+    relocate "io.opencensus", "io.pravega.shaded.io.opencensus"
+    relocate "io.netty", "io.pravega.shaded.io.netty"
+    relocate 'META-INF/native/libnetty', 'META-INF/native/libio_pravega_shaded_netty'
+    relocate 'META-INF/native/netty', 'META-INF/native/io_pravega_shaded_netty'
 }
 
 javadoc {

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ sparkVersion=2.4.6
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.7.0-SNAPSHOT
-pravegaVersion=0.7.0
+pravegaVersion=0.8.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,7 @@ slf4jApiVersion=1.7.25
 sparkVersion=2.4.6
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.7.0-SNAPSHOT
+connectorVersion=0.8.0-SNAPSHOT
 pravegaVersion=0.8.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'


### PR DESCRIPTION
Added shading for grpc-netty upgrade and upgraded pravega version to 0.8. Tested using historical stream processing examples such as word generator and line counter using a netty version of 4.1.30.Final