### PR TITLE
Issue 88 upgrade to spark 2.4.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,21 +69,21 @@ dependencies {
     compile group: 'org.scala-lang', name: 'scala-library', version: scalaVersion
     compile group: 'org.scala-lang', name: 'scala-reflect', version: scalaVersion
     compile group: 'org.scala-lang', name: 'scala-compiler', version: scalaVersion
-    compile group: 'org.scala-lang.modules', name: 'scala-java8-compat_2.11', version: scalaJava8CompatVersion
-    compile group: 'com.jsuereth', name: 'scala-arm_2.11', version: scalaArmVersion
+    compile group: 'org.scala-lang.modules', name: 'scala-java8-compat_2.12', version: scalaJava8CompatVersion
+    compile group: 'com.jsuereth', name: 'scala-arm_2.12', version: scalaArmVersion
 
-    compileOnly group: 'org.apache.spark', name: 'spark-sql_2.11', version: sparkVersion
-    shadowOnly group: 'org.apache.spark', name: 'spark-sql_2.11', version: sparkVersion
+    compileOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
+    shadowOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
 
     testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'org.scalatest', name: 'scalatest_2.11', version: scalaTestVersion
-    testCompile group: 'org.apache.spark', name: 'spark-sql_2.11', version: sparkVersion
-    testCompile group: 'org.apache.spark', name: 'spark-core_2.11', version: sparkVersion, classifier: 'tests'
-    testCompile group: 'org.apache.spark', name: 'spark-catalyst_2.11', version: sparkVersion, classifier: 'tests'
-    testCompile group: 'org.apache.spark', name: 'spark-sql_2.11', version: sparkVersion, classifier: 'tests'
+    testCompile group: 'org.scalatest', name: 'scalatest_2.12', version: scalaTestVersion
+    testCompile group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
+    testCompile group: 'org.apache.spark', name: 'spark-core_2.12', version: sparkVersion, classifier: 'tests'
+    testCompile group: 'org.apache.spark', name: 'spark-catalyst_2.12', version: sparkVersion, classifier: 'tests'
+    testCompile group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion, classifier: 'tests'
     testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
     testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.11', version: jacksonVersion
+    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.12', version: jacksonVersion
 }
 
 configurations {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,10 +19,10 @@ logbackVersion=1.1.7
 scalaJava8CompatVersion=0.9.1
 scalaTestVersion=3.0.5
 scalaArmVersion=2.0
-scalaVersion=2.11.12
+scalaVersion=2.12.13
 shadowGradlePlugin=4.0.2
 slf4jApiVersion=1.7.25
-sparkVersion=2.4.6
+sparkVersion=2.4.7
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.9.0-SNAPSHOT

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -24,7 +24,12 @@ compileJava {
     ])
 }
 
-archivesBaseName = "pravega-connectors-spark"
+def getMajorMinorVersion(inputVersion) {
+    String ver = inputVersion
+    return ver.substring(0, ver.lastIndexOf('.'))
+}
+
+archivesBaseName = "pravega-connectors-spark-" + getMajorMinorVersion(sparkVersion) + '_' + getMajorMinorVersion(scalaVersion)
 
 assemble.dependsOn(shadowJar)
 


### PR DESCRIPTION
[Issue-88] Upgrade Spark 2.4 connector to Spark 2.4.7
[Issue-86] Update to Scala 2.12 in spark 2.4 connector

All tests passed but meanwhile also see the following exceptions raised, please confirm.

```
03:48:04,206 ERROR org.apache.spark.executor.Executor                            - Exception in task 1.0 in stage 54.0 (TID 79)
java.lang.IllegalStateException: routing_key attribute type must be a string; received unsupported type int
        at io.pravega.connectors.spark.TransactionPravegaDataWriter.createProjection(TransactionPravegaWriter.scala:280)        at io.pravega.connectors.spark.TransactionPravegaDataWriter.<init>(TransactionPravegaWriter.scala:186)
        at io.pravega.connectors.spark.TransactionPravegaWriterFactory.createDataWriter(TransactionPravegaWriter.scala:167)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:113)
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.$anonfun$doExecute$2(WriteToDataSourceV2Exec.scala:67)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:411)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
03:48:04,206 ERROR org.apache.spark.executor.Executor                            - Exception in task 0.0 in stage 54.0 (TID 78)
java.lang.IllegalStateException: routing_key attribute type must be a string; received unsupported type int
        at io.pravega.connectors.spark.TransactionPravegaDataWriter.createProjection(TransactionPravegaWriter.scala:280)        at io.pravega.connectors.spark.TransactionPravegaDataWriter.<init>(TransactionPravegaWriter.scala:186)
        at io.pravega.connectors.spark.TransactionPravegaWriterFactory.createDataWriter(TransactionPravegaWriter.scala:167)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:113)
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.$anonfun$doExecute$2(WriteToDataSourceV2Exec.scala:67)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:411)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
03:48:04,208 ERROR org.apache.spark.scheduler.TaskSetManager                     - Task 1 in stage 54.0 failed 1 times; aborting job
03:48:04,209 ERROR org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec  - Data source writer org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter@d6eed0d is aborting.
03:48:04,210 ERROR org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec  - Data source writer org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter@d6eed0d failed to abort.
03:48:04,211 ERROR org.apache.spark.sql.execution.streaming.MicroBatchExecution  - Query pravegaStream [id = 978a7776-b3d8-4076-8705-fb1c03f89b10, runId = 1c8e8792-001a-4594-9a5e-cbf6a1f0b72b] terminated with error
org.apache.spark.SparkException: Writing job failed.
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.doExecute(WriteToDataSourceV2Exec.scala:87)
        at org.apache.spark.sql.execution.SparkPlan.$anonfun$execute$1(SparkPlan.scala:131)
        at org.apache.spark.sql.execution.SparkPlan.$anonfun$executeQuery$1(SparkPlan.scala:155)
        at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
        at org.apache.spark.sql.execution.SparkPlan.executeQuery(SparkPlan.scala:152)
        at org.apache.spark.sql.execution.SparkPlan.execute(SparkPlan.scala:127)
        at org.apache.spark.sql.execution.SparkPlan.getByteArrayRdd(SparkPlan.scala:247)
        at org.apache.spark.sql.execution.SparkPlan.executeCollect(SparkPlan.scala:296)
        at org.apache.spark.sql.Dataset.collectFromPlan(Dataset.scala:3389)
        at org.apache.spark.sql.Dataset.$anonfun$collect$1(Dataset.scala:2788)
        at org.apache.spark.sql.Dataset.$anonfun$withAction$2(Dataset.scala:3370)
        at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:80)
        at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:127)
        at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:75)
        at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3370)
        at org.apache.spark.sql.Dataset.collect(Dataset.scala:2788)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$15(MicroBatchExecution.scala:540)
        at org.apache.spark.sql.execution.SQLExecution$.$anonfun$withNewExecutionId$1(SQLExecution.scala:80)
        at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:127)
        at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:75)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runBatch$14(MicroBatchExecution.scala:536)
        at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:351)
        at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:349)
        at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:58)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runBatch(MicroBatchExecution.scala:535)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$2(MicroBatchExecution.scala:198)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken(ProgressReporter.scala:351)
        at org.apache.spark.sql.execution.streaming.ProgressReporter.reportTimeTaken$(ProgressReporter.scala:349)
        at org.apache.spark.sql.execution.streaming.StreamExecution.reportTimeTaken(StreamExecution.scala:58)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.$anonfun$runActivatedStream$1(MicroBatchExecution.scala:166)
        at org.apache.spark.sql.execution.streaming.ProcessingTimeExecutor.execute(TriggerExecutor.scala:56)
        at org.apache.spark.sql.execution.streaming.MicroBatchExecution.runActivatedStream(MicroBatchExecution.scala:160)
        at org.apache.spark.sql.execution.streaming.StreamExecution.org$apache$spark$sql$execution$streaming$StreamExecution$$runStream(StreamExecution.scala:281)
        at org.apache.spark.sql.execution.streaming.StreamExecution$$anon$1.run(StreamExecution.scala:193)
Caused by: org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 54.0 failed 1 times, most recent failure: Lost task 1.0 in stage 54.0 (TID 79, localhost, executor driver): java.lang.IllegalStateException: routing_key attribute type must be a string; received unsupported type int
        at io.pravega.connectors.spark.TransactionPravegaDataWriter.createProjection(TransactionPravegaWriter.scala:280)        at io.pravega.connectors.spark.TransactionPravegaDataWriter.<init>(TransactionPravegaWriter.scala:186)
        at io.pravega.connectors.spark.TransactionPravegaWriterFactory.createDataWriter(TransactionPravegaWriter.scala:167)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:113)
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.$anonfun$doExecute$2(WriteToDataSourceV2Exec.scala:67)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:411)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)

Driver stacktrace:
        at org.apache.spark.scheduler.DAGScheduler.failJobAndIndependentStages(DAGScheduler.scala:1925)
        at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2(DAGScheduler.scala:1913)
        at org.apache.spark.scheduler.DAGScheduler.$anonfun$abortStage$2$adapted(DAGScheduler.scala:1912)
        at scala.collection.mutable.ResizableArray.foreach(ResizableArray.scala:62)
        at scala.collection.mutable.ResizableArray.foreach$(ResizableArray.scala:55)
        at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:49)
        at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1912)
        at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1(DAGScheduler.scala:948)
        at org.apache.spark.scheduler.DAGScheduler.$anonfun$handleTaskSetFailed$1$adapted(DAGScheduler.scala:948)
        at scala.Option.foreach(Option.scala:407)
        at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:948)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2146)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2095)
        at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2084)
        at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
        at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:759)
        at org.apache.spark.SparkContext.runJob(SparkContext.scala:2061)
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.doExecute(WriteToDataSourceV2Exec.scala:64)
        ... 34 more
        Suppressed: java.lang.NullPointerException
                at io.pravega.connectors.spark.TransactionPravegaWriter.$anonfun$abort$6(TransactionPravegaWriter.scala:123)
                at scala.collection.TraversableLike.$anonfun$map$1(TraversableLike.scala:286)
                at scala.collection.IndexedSeqOptimized.foreach(IndexedSeqOptimized.scala:36)
                at scala.collection.IndexedSeqOptimized.foreach$(IndexedSeqOptimized.scala:33)
                at scala.collection.mutable.ArrayOps$ofRef.foreach(ArrayOps.scala:198)
                at scala.collection.TraversableLike.map(TraversableLike.scala:286)
                at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
                at scala.collection.mutable.ArrayOps$ofRef.map(ArrayOps.scala:198)
                at io.pravega.connectors.spark.TransactionPravegaWriter.$anonfun$abort$4(TransactionPravegaWriter.scala:123)
                at io.pravega.connectors.spark.TransactionPravegaWriter.$anonfun$abort$4$adapted(TransactionPravegaWriter.scala:118)
                at resource.AbstractManagedResource.$anonfun$acquireFor$1(AbstractManagedResource.scala:88)
                at scala.util.control.Exception$Catch.$anonfun$either$1(Exception.scala:252)
                at scala.util.control.Exception$Catch.apply(Exception.scala:228)
                at scala.util.control.Exception$Catch.either(Exception.scala:252)
                at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:88)
                at resource.ManagedResourceOperations.apply(ManagedResourceOperations.scala:26)
                at resource.ManagedResourceOperations.apply$(ManagedResourceOperations.scala:26)
                at resource.AbstractManagedResource.apply(AbstractManagedResource.scala:50)
                at resource.ManagedResourceOperations.acquireAndGet(ManagedResourceOperations.scala:25)
                at resource.ManagedResourceOperations.acquireAndGet$(ManagedResourceOperations.scala:25)
                at resource.AbstractManagedResource.acquireAndGet(AbstractManagedResource.scala:50)
                at resource.ManagedResourceOperations.foreach(ManagedResourceOperations.scala:53)
                at resource.ManagedResourceOperations.foreach$(ManagedResourceOperations.scala:53)
                at resource.AbstractManagedResource.foreach(AbstractManagedResource.scala:50)
                at io.pravega.connectors.spark.TransactionPravegaWriter.$anonfun$abort$2(TransactionPravegaWriter.scala:118)
                at io.pravega.connectors.spark.TransactionPravegaWriter.$anonfun$abort$2$adapted(TransactionPravegaWriter.scala:117)
                at resource.AbstractManagedResource.$anonfun$acquireFor$1(AbstractManagedResource.scala:88)
                at scala.util.control.Exception$Catch.$anonfun$either$1(Exception.scala:252)
                at scala.util.control.Exception$Catch.apply(Exception.scala:228)
                at scala.util.control.Exception$Catch.either(Exception.scala:252)
                at resource.AbstractManagedResource.acquireFor(AbstractManagedResource.scala:88)
                at resource.ManagedResourceOperations.apply(ManagedResourceOperations.scala:26)
                at resource.ManagedResourceOperations.apply$(ManagedResourceOperations.scala:26)
                at resource.AbstractManagedResource.apply(AbstractManagedResource.scala:50)
                at resource.ManagedResourceOperations.acquireAndGet(ManagedResourceOperations.scala:25)
                at resource.ManagedResourceOperations.acquireAndGet$(ManagedResourceOperations.scala:25)
                at resource.AbstractManagedResource.acquireAndGet(AbstractManagedResource.scala:50)
                at resource.ManagedResourceOperations.foreach(ManagedResourceOperations.scala:53)
                at resource.ManagedResourceOperations.foreach$(ManagedResourceOperations.scala:53)
                at resource.AbstractManagedResource.foreach(AbstractManagedResource.scala:50)
                at io.pravega.connectors.spark.TransactionPravegaWriter.abort(TransactionPravegaWriter.scala:117)
                at org.apache.spark.sql.execution.streaming.sources.MicroBatchWriter.abort(MicroBatchWriter.scala:34)
                at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.doExecute(WriteToDataSourceV2Exec.scala:82)
                ... 34 more
Caused by: java.lang.IllegalStateException: routing_key attribute type must be a string; received unsupported type int
        at io.pravega.connectors.spark.TransactionPravegaDataWriter.createProjection(TransactionPravegaWriter.scala:280)        at io.pravega.connectors.spark.TransactionPravegaDataWriter.<init>(TransactionPravegaWriter.scala:186)
        at io.pravega.connectors.spark.TransactionPravegaWriterFactory.createDataWriter(TransactionPravegaWriter.scala:167)
        at org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTask$.run(WriteToDataSourceV2Exec.scala:113)
        at org.apache.spark.sql.execution.datasources.v2.WriteToDataSourceV2Exec.$anonfun$doExecute$2(WriteToDataSourceV2Exec.scala:67)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:411)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:414)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
- streaming - write data with valid schema but wrong types, with transaction (3 seconds, 77 milliseconds)
03:48:05,785 ERROR org.apache.spark.sql.execution.streaming.MicroBatchExecution  - Query pravegaStream [id = c0311e21-c69e-4f06-a00c-5fd795e4ca54, runId = b6663cf1-ff14-463f-8775-49ba173b305e] terminated with error
java.lang.IllegalArgumentException: Scope does not exist: StreamConfiguration(scalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, scaleFactor=0, minNumSegments=1), retentionPolicy=null, timestampAggregationTimeout=0)
        at io.pravega.client.control.impl.ControllerImpl.lambda$createStream$17(ControllerImpl.java:461)
        at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
        at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:714)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
        at io.pravega.client.control.impl.ControllerImpl$RPCAsyncCallback.onCompleted(ControllerImpl.java:1720)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:440)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.internal.CensusStatsModule$StatsClientInterceptor$1$1.onClose(CensusStatsModule.java:700)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.internal.CensusTracingModule$TracingClientInterceptor$1$1.onClose(CensusTracingModule.java:399)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:510)
        at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:66)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.close(ClientCallImpl.java:630)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.access$700(ClientCallImpl.java:518)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:692)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:681)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
- streaming - write to non-existing scope, with non-transaction (1 second, 573 milliseconds)
03:48:07,124 ERROR org.apache.spark.sql.execution.streaming.MicroBatchExecution  - Query pravegaStream [id = 8b9bf3c7-37d6-40ac-a63d-af4ed2148246, runId = 1753c159-1da0-41e2-a84c-7839573c8b1e] terminated with error
java.lang.IllegalArgumentException: Scope does not exist: StreamConfiguration(scalingPolicy=ScalingPolicy(scaleType=FIXED_NUM_SEGMENTS, targetRate=0, scaleFactor=0, minNumSegments=1), retentionPolicy=null, timestampAggregationTimeout=0)
        at io.pravega.client.control.impl.ControllerImpl.lambda$createStream$17(ControllerImpl.java:461)
        at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
        at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:714)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
        at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073)
        at io.pravega.client.control.impl.ControllerImpl$RPCAsyncCallback.onCompleted(ControllerImpl.java:1720)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:440)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.internal.CensusStatsModule$StatsClientInterceptor$1$1.onClose(CensusStatsModule.java:700)
        at io.grpc.PartialForwardingClientCallListener.onClose(PartialForwardingClientCallListener.java:39)
        at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:23)
        at io.grpc.ForwardingClientCallListener$SimpleForwardingClientCallListener.onClose(ForwardingClientCallListener.java:40)
        at io.grpc.internal.CensusTracingModule$TracingClientInterceptor$1$1.onClose(CensusTracingModule.java:399)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:510)
        at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:66)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.close(ClientCallImpl.java:630)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.access$700(ClientCallImpl.java:518)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInternal(ClientCallImpl.java:692)
        at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:681)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```