### PR TITLE
[Issue-108] Spark fail to bind the address in the tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on: [push, pull_request, workflow_dispatch]
 env:
   GRADLE_OPTS: "-Xms128m -Xmx1024m"
   ORG_GRADLE_PROJECT_logOutput: true
+  SPARK_LOCAL_IP: "127.0.0.1"
 
 jobs:
   build:


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**

Make the tests pass in Github Actions.

**Purpose of the change**

Fixes #108 

**What the code does**

Explicitly set the appropriate binding address for the `SharedSparkSession`.

**How to verify it**

Github Actions could build successfully.
