### PR TITLE
[Issue-110] Wrong commit count number of the artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**

A typical name of the artifact should be something like `0.10.0-1.ff9f6d1-SNAPSHOT`, with the `[version]-[commit count]-[commit sha]-SNAPSHOT` format.
But for artifacts produced by Github Actions, the commit count are always set to 1. This is because the default settings of the `actions/checkout` plugin will only fetch the most recent single commit.

**Purpose of the change**

Fixes #110 

**What the code does**

Add a parameter to specify the clone depth to be unlimited.

**How to verify it**

Artifacts build by the new yaml should have the corret commit count.
