### PR TITLE
[issue-112] upgrade pravega client version to 0.9.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,8 @@ slf4jApiVersion=1.7.25
 sparkVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.9.0-SNAPSHOT
-pravegaVersion=0.9.0-2725.77b1398-SNAPSHOT
+connectorVersion=0.9.1-SNAPSHOT
+pravegaVersion=0.9.1-2777.26b543c-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Run completed in 4 minutes, 55 seconds.
Total number of tests run: 49
Suites: completed 6, aborted 0
Tests: succeeded 49, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 5m 16s
8 actionable tasks: 4 executed, 4 up-to-date