### PR TITLE
[Issue-118] Publish snapshot artifacts in GitHub Packages Registry but not in JCenter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
         run: ./gradlew clean build
 
   snapshot:
-    name: Publish snapshot
+    name: Publish snapshot to Github Packages
     needs: [build]
     runs-on: ubuntu-20.04
     # only publish the snapshot when it is a push on the master or the release branch (starts with r0.x or r1.x)
@@ -79,5 +79,5 @@ jobs:
           path: ./*
           key: ${{ github.run_id }}
 
-      - name: Publish to repo
-        run: ./gradlew publishToRepo -PpublishUrl=jcenterSnapshot -PpublishUsername=$BINTRAY_USER -PpublishPassword=$BINTRAY_KEY
+      - name: Publish to Github Packages
+        run: ./gradlew publishToRepo -PpublishUrl=https://maven.pkg.github.com/${{github.repository}} -PpublishUsername=${{github.actor}} -PpublishPassword=${{secrets.GITHUB_TOKEN}}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,10 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath "com.github.jengelman.gradle.plugins:shadow:${shadowGradlePlugin}"
@@ -45,11 +48,16 @@ tasks.withType(JavaCompile) {
 
 repositories {
     mavenLocal()
-    jcenter()
     mavenCentral()
+    maven {
+        url "https://maven.pkg.github.com/pravega/pravega"
+        credentials {
+            username = "pravega-public"
+            password = "\u0067\u0068\u0070\u005F\u0048\u0034\u0046\u0079\u0047\u005A\u0031\u006B\u0056\u0030\u0051\u0070\u006B\u0079\u0058\u006D\u0035\u0063\u0034\u0055\u0033\u006E\u0032\u0065\u0078\u0039\u0032\u0046\u006E\u0071\u0033\u0053\u0046\u0076\u005A\u0049"
+        }
+    }
     maven { url "https://repository.apache.org/snapshots" }
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-    maven { url "https://oss.jfrog.org/jfrog-dependencies" }
     if (findProperty("repositoryUrl")) {
         maven {
             url findProperty("repositoryUrl")
@@ -59,6 +67,10 @@ repositories {
 
 configurations {
     shadowOnly {
+    }
+    all {
+        testImplementation.extendsFrom(compileOnly)
+        testImplementation.exclude group: 'io.netty', module: 'netty-all'
     }
 }
 
@@ -73,17 +85,33 @@ dependencies {
     compileOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
     shadowOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
 
-    testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
-    testCompile group: 'org.scalatest', name: 'scalatest_2.12', version: scalaTestVersion
-    testCompile group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
-    testCompile group: 'org.apache.spark', name: 'spark-core_2.12', version: sparkVersion, classifier: 'tests'
-    testCompile group: 'org.apache.spark', name: 'spark-catalyst_2.12', version: sparkVersion, classifier: 'tests'
-    testCompile group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion, classifier: 'tests'
-    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
-    testCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.12', version: jacksonVersion
-    testCompile group: 'io.pravega', name: 'pravega-test-integration', version: pravegaVersion
+    testImplementation group: 'junit', name: 'junit', version: junitVersion
+    testImplementation (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+    }
+    testImplementation (group: 'org.apache.zookeeper', name: 'zookeeper') {
+        version {
+            strictly '3.5.9'
+        }
+    }
+    testImplementation (group: 'io.netty', name: 'netty-all') {
+        version {
+            strictly '4.1.65.Final'
+        }
+    }
+    testImplementation group: 'org.scalatest', name: 'scalatest_2.12', version: scalaTestVersion
+    testImplementation (group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion) {
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+    }
+    testImplementation (group: 'org.apache.spark', name: 'spark-core_2.12', version: sparkVersion, classifier: 'tests') {
+        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
+    }
+    testImplementation group: 'org.apache.spark', name: 'spark-catalyst_2.12', version: sparkVersion, classifier: 'tests'
+    testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion, classifier: 'tests'
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: jacksonVersion
+    testImplementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.12', version: jacksonVersion
+    testImplementation group: 'io.pravega', name: 'pravega-test-integration', version: pravegaVersion
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -86,26 +86,15 @@ dependencies {
     shadowOnly group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
 
     testImplementation group: 'junit', name: 'junit', version: junitVersion
-    testImplementation (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion) {
-        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
-    }
+    testImplementation group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion
     testImplementation (group: 'org.apache.zookeeper', name: 'zookeeper') {
         version {
             strictly '3.5.9'
         }
     }
-    testImplementation (group: 'io.netty', name: 'netty-all') {
-        version {
-            strictly '4.1.65.Final'
-        }
-    }
     testImplementation group: 'org.scalatest', name: 'scalatest_2.12', version: scalaTestVersion
-    testImplementation (group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion) {
-        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
-    }
-    testImplementation (group: 'org.apache.spark', name: 'spark-core_2.12', version: sparkVersion, classifier: 'tests') {
-        exclude group: 'org.apache.zookeeper', module: 'zookeeper'
-    }
+    testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion
+    testImplementation group: 'org.apache.spark', name: 'spark-core_2.12', version: sparkVersion, classifier: 'tests'
     testImplementation group: 'org.apache.spark', name: 'spark-catalyst_2.12', version: sparkVersion, classifier: 'tests'
     testImplementation group: 'org.apache.spark', name: 'spark-sql_2.12', version: sparkVersion, classifier: 'tests'
     testImplementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: jacksonVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ sparkVersion=3.0.1
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2869.842cbda-SNAPSHOT
+pravegaVersion=0.10.0-2917.d58e537-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: zhongle.wang <zhongle_wang@dell.com>

**Change log description**
Changes the destination for snapshot artifacts from JCenter to GitHub Packages Registry.

**Purpose of the change**
Fixes #118 

**What the code does**
Snapshot action from build workflow is updated to publish to GPR:

- It uses auto-generated GITHUB_TOKEN token which is valid only in current repository
- By default publishes to owner/repository which is a repository where the action is executed
- Removes jcenter()/jfrog references from build scripts
- Exclude zookeeper 3.6.2 imported by pravega-standalone and wait for pravega/pravega#6129
- Exclude netty-all < 4.1.65 which can cause an api mismatch

**How to verify it**
Once PR is merged the next build on master branch must produce snapshot artifacts in GPR

**Known Limitations**

- Packages are not auto-deleted after some time. This will be addressed separately
- Using snapshot packages in other repository is not allowed without the authentication.

Limitation 2 can be handled in the following way:

- Create import token in pravega repository with read:packages scope. This can be shared with others
- In the other repository add the following to repositories list

```
maven {
           url "https://maven.pkg.github.com/pravega/pravega"
           credentials {
             username = "pravega"
             password = IMPORT_TOKEN // this is token created above 
           }
       }
```