### PR TITLE
[issue-122] Upgrade Pravega client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The [master](https://github.com/pravega/spark-connectors) branch will always hav
 
 | Spark Version | Pravega Version | Java Version To Build Connector | Java Version To Run Connector | Git Branch                                                                        |
 |---------------|-----------------|---------------------------------|-------------------------------|-----------------------------------------------------------------------------------|
-| 3.1           | 1.10            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)
-| 3.0           | 1.10            | Java 11                         | Java 8 or 11                  | [r0.10-spark3.0](https://github.com/pravega/spark-connectors/tree/r0.10-spark3.0)                             |
+| 3.1           | 0.10            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)
+| 3.0           | 0.10            | Java 11                         | Java 8 or 11                  | [r0.10-spark3.0](https://github.com/pravega/spark-connectors/tree/r0.10-spark3.0)                             |
 | 2.4           | 0.10            | Java 8                          | Java 8                        | [r0.10-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.10-spark2.4) |
 | 3.0           | 0.9             | Java 11                         | Java 8 or 11                  | [r0.9](https://github.com/pravega/spark-connectors/tree/r0.9)                     |
 | 2.4           | 0.9             | Java 8                          | Java 8                        | [r0.9-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.9-spark2.4)   |

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,13 +20,13 @@ scalaJava8CompatVersion=0.9.1
 scalaTestVersion=3.1.0
 scalaArmVersion=2.0
 scalaVersion=2.12.13
-shadowGradlePlugin=4.0.2
+shadowGradlePlugin=6.1.0
 slf4jApiVersion=1.7.25
 sparkVersion=3.1.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0
+pravegaVersion=0.10.0-2979.39e8216-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ sparkVersion=3.1.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.10.0-SNAPSHOT
-pravegaVersion=0.10.0-2917.d58e537-SNAPSHOT
+pravegaVersion=0.10.0
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Fan Yang <fan.yang5@emc.com>

**Change log description**
- Upgrade Pravega client version to the latest commit https://github.com/pravega/pravega/commit/39e82164bb1b5f41a9e979d3d442432a7258a675

**Purpose of the change**
Fix #122 

**What the code does**
- Change pravega client version in `gradle.properties`
- Upgrade gradle shadow plugin version to `6.1.0`

**How to verify it**
`./gradlew clean build` passed