### PR TITLE
[Issue-128] Update connector to 0.11.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ sparkVersion=3.1.2
 
 # Version and base tags can be overridden at build time.
 connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.10.1-2988.12af542-SNAPSHOT
+pravegaVersion=0.11.0-3003.e72f61e-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: thekingofcity <3353040+thekingofcity@users.noreply.github.com>

**Change log description**
Update connector version to 0.11.0-SNAPSHOT

**Purpose of the change**
Fix #128 

**What the code does**
Update connector version and pravega version in `gradle.properties`.

**How to verify it**
`./gradlew clean build` should pass.
