### PR TITLE
upgrade pravega client version to 0.10.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 build/
 metastore_db/
 out/
+bin/
 spark-warehouse/
 travis.log
 *input.txt

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,8 @@ slf4jApiVersion=1.7.25
 sparkVersion=3.1.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.11.0-3003.e72f61e-SNAPSHOT
+connectorVersion=0.10.1
+pravegaVersion=0.10.1
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Luis Liu <luis_liu@dell.com>

Change log description
Update connector version to 0.10.1

Purpose of the change
Fix #134

What the code does
Update connector version and pravega version in gradle.properties.

How to verify it
./gradlew clean build test pass.

```
Run completed in 2 minutes, 13 seconds.
Total number of tests run: 49
Suites: completed 6, aborted 0
Tests: succeeded 49, failed 0, canceled 0, ignored 0, pending 0
All tests passed.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4m 27s
9 actionable tasks: 7 executed, 2 up-to-date
```