### PR TITLE
[Issue-140] Update connector version to 0.11.1-SNAPSHOT on r0.11 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,12 @@ The [master](https://github.com/pravega/spark-connectors) branch will always hav
 
 | Spark Version | Pravega Version | Java Version To Build Connector | Java Version To Run Connector | Git Branch                                                                        |
 |---------------|-----------------|---------------------------------|-------------------------------|-----------------------------------------------------------------------------------|
-| 3.1           | 0.10            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)
-| 3.0           | 0.10            | Java 11                         | Java 8 or 11                  | [r0.10-spark3.0](https://github.com/pravega/spark-connectors/tree/r0.10-spark3.0)                             |
+| 3.1           | 0.12            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)                             |
+| 3.1           | 0.11            | Java 11                         | Java 8 or 11                  | [r0.11](https://github.com/pravega/spark-connectors/tree/r0.11)                   |
+| 2.4           | 0.11            | Java 8                          | Java 8                        | [r0.11-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.11-spark2.4) |
+| 3.1           | 0.10            | Java 11                         | Java 8 or 11                  | [r0.10](https://github.com/pravega/spark-connectors/tree/r0.10)                   |
+| 3.0           | 0.10            | Java 11                         | Java 8 or 11                  | [r0.10-spark3.0](https://github.com/pravega/spark-connectors/tree/r0.10-spark3.0) |
 | 2.4           | 0.10            | Java 8                          | Java 8                        | [r0.10-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.10-spark2.4) |
-| 3.0           | 0.9             | Java 11                         | Java 8 or 11                  | [r0.9](https://github.com/pravega/spark-connectors/tree/r0.9)                     |
-| 2.4           | 0.9             | Java 8                          | Java 8                        | [r0.9-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.9-spark2.4)   |
-| 3.0           | 0.8             | Java 8                          | Java 8                        | [r0.8-spark3.0](https://github.com/pravega/spark-connectors/tree/r0.8-spark3.0)   |
-| 2.4           | 0.8             | Java 8                          | Java 8                        | [r0.8-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.8-spark2.4)   |
 
 ## Support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,8 +25,8 @@ slf4jApiVersion=1.7.25
 sparkVersion=3.1.2
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.11.0-SNAPSHOT
-pravegaVersion=0.11.0-3003.e72f61e-SNAPSHOT
+connectorVersion=0.11.1-SNAPSHOT
+pravegaVersion=0.11.1-3057.de5dccf-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

**Change log description**
Update connector and Pravega version to `0.11.1-SNAPSHOT` 
Update the compatibility matrix in `README.md`

**Purpose of the change**
Fix #140  

**What the code does**
Update `connectorVersion` and `pravegaVersion` in `gradle.properties`
Update `README.md`

**How to verify it**
`./gradlew clean build` should pass