### PR TITLE
[Issue-152] Force guava version to `30.1-jre`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,9 @@ configurations {
     all {
         testImplementation.extendsFrom(compileOnly)
         testImplementation.exclude group: 'io.netty', module: 'netty-all'
+        resolutionStrategy {
+            force "com.google.guava:guava:" + guavaVersion
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,7 @@
 checkstyleToolVersion=7.1
 curatorVersion=4.0.0
 gradleGitPluginVersion=1.7.2
+guavaVersion=30.1-jre
 hadoopVersion=2.8.1
 jacksonVersion=2.11.0
 junitVersion=4.12


### PR DESCRIPTION
Signed-off-by: Fan, Yang <fan.yang5@emc.com>

Force guava version to `30.1-jre` to prevent from being bumped to `31.0.1-android` with grpc upgrade in https://github.com/pravega/pravega/commit/572aae50332da36d81b8ee8e9c366b203b81d840 