### PR TITLE
[issue-166] Update connector version to 0.14.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 -->
 
-# Pravega Spark Connectors [![Build Status](https://travis-ci.org/pravega/spark-connectors.svg?branch=master)](https://travis-ci.org/pravega/spark-connectors) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+# Pravega Spark Connectors [![Build Status](https://github.com/pravega/spark-connectors/actions/workflows/build.yml/badge.svg)](https://github.com/pravega/spark-connectors/actions/workflows/build.yml?query=branch%3Amaster) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 This repository implements connectors to read and write [Pravega](http://pravega.io/) Streams with [Apache Spark](http://spark.apache.org/), a high-performance analytics engine for batch and streaming data.
 
@@ -37,14 +37,10 @@ To learn more about Pravega, visit https://pravega.io
 
 The [master](https://github.com/pravega/spark-connectors) branch will always have the most recent supported versions of Spark and Pravega.
 
-| Spark Version | Pravega Version | Java Version To Build Connector | Java Version To Run Connector | Git Branch                                                                        |
-|---------------|-----------------|---------------------------------|-------------------------------|-----------------------------------------------------------------------------------|
-| 3.1+          | 0.13            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)                             |
-| 2.4           | 0.13            | Java 8                          | Java 8                        | [r0.13-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.13-spark2.4) |
-| 3.1+          | 0.12            | Java 11                         | Java 8 or 11                  | [r0.12](https://github.com/pravega/spark-connectors/tree/r0.12)                   |
-| 2.4           | 0.12            | Java 8                          | Java 8                        | [r0.12-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.12-spark2.4) |
-| 3.1+          | 0.11            | Java 11                         | Java 8 or 11                  | [r0.11](https://github.com/pravega/spark-connectors/tree/r0.11)                   |
-| 2.4           | 0.11            | Java 8                          | Java 8                        | [r0.11-spark2.4](https://github.com/pravega/spark-connectors/tree/r0.11-spark2.4) |
+| Spark Version | Pravega Version | Java Version To Build Connector | Java Version To Run Connector | Git Branch                                                      |
+|---------------|-----------------|---------------------------------|-------------------------------|-----------------------------------------------------------------|
+| 3.4           | 0.14            | Java 11                         | Java 8 or 11                  | [master](https://github.com/pravega/spark-connectors)           |
+| 3.4           | 0.13            | Java 11                         | Java 8 or 11                  | [r0.13](https://github.com/pravega/spark-connectors/tree/r0.13) |
 
 ## Support
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,8 @@ slf4jApiVersion=1.7.25
 sparkVersion=3.4.0
 
 # Version and base tags can be overridden at build time.
-connectorVersion=0.13.0-SNAPSHOT
-pravegaVersion=0.13.0-3142.2542966-SNAPSHOT
+connectorVersion=0.14.0-SNAPSHOT
+pravegaVersion=0.14.0-3257.fd53bec-SNAPSHOT
 
 # flag to indicate if Pravega sub-module should be used instead of the version defined in 'pravegaVersion'
 usePravegaVersionSubModule=false


### PR DESCRIPTION
**Change log description**
Update connector and Pravega version to `0.14.0-SNAPSHOT`
Update the compatibility matrix in `README.md`

**Purpose of the change**
Fix #166 

**What the code does**
Update `connectorVersion` and `pravegaVersion` in `gradle.properties`
Update `README.md`

**How to verify it**
`./gradlew clean build` should pass